### PR TITLE
⚡ Bolt: Extract constant arrays from SettingsModal render

### DIFF
--- a/.Jules/bolt.md
+++ b/.Jules/bolt.md
@@ -1,0 +1,9 @@
+# Performance Journal - Coffee Pulse
+
+## Memory Allocation & Render Performance
+
+### Static Array Extractions (2025-03-14)
+- **Problem**: Inline array literals like `[15, 30, 45, 60, 75].map(...)` inside a React component's render body cause a new array to be allocated on every single render.
+- **Impact**: While small, frequent re-renders (common in apps with timers or animations) can lead to increased GC pressure and potential micro-stuttering.
+- **Solution**: Extracted these arrays to module-level constants (`COFFEE_PRESETS`, `THEME_SWATCH_PHASES`). This ensures the array is created only once when the module is loaded.
+- **Learning**: Proactively identifying static data in render loops is a low-effort, high-reward habit for maintaining "buttery smooth" UI performance.

--- a/components/SettingsModal.tsx
+++ b/components/SettingsModal.tsx
@@ -46,6 +46,11 @@ const hintText = (t: Theme): React.CSSProperties => ({
   letterSpacing: '0.04em', color: a(t.text, 0.55), marginTop: 6,
 });
 
+// ─── Constants ────────────────────────────────────────────────────────────────
+
+const COFFEE_PRESETS = [15, 30, 45, 60, 75];
+const THEME_SWATCH_PHASES = [TimerPhase.BLOOM, TimerPhase.POUR, TimerPhase.WAIT, TimerPhase.IDLE];
+
 // ─── Component ────────────────────────────────────────────────────────────────
 
 export const SettingsModal: React.FC<SettingsModalProps> = ({
@@ -179,7 +184,7 @@ export const SettingsModal: React.FC<SettingsModalProps> = ({
                     }}>
                       {/* Phase colour dots arranged in a 2×2 grid */}
                       <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 3 }}>
-                        {([TimerPhase.BLOOM, TimerPhase.POUR, TimerPhase.WAIT, TimerPhase.IDLE] as TimerPhase[]).map(p => (
+                        {THEME_SWATCH_PHASES.map(p => (
                           <div key={p} style={{
                             width: 7, height: 7, borderRadius: '50%',
                             background: t.phases[p].ring,
@@ -219,7 +224,7 @@ export const SettingsModal: React.FC<SettingsModalProps> = ({
             <div style={{ marginBottom: 12 }}>
               <label htmlFor="coffeeWeight" style={fieldLabel(theme)}>Coffee (g)</label>
               <div style={{ display: 'flex', gap: 7, marginBottom: 8 }}>
-                {[15, 30, 45, 60, 75].map(g => {
+                {COFFEE_PRESETS.map(g => {
                   const active = local.coffeeWeight === g;
                   return (
                     <button


### PR DESCRIPTION
💡 **What:**
Extracted two inline array literals used in `.map()` calls within `components/SettingsModal.tsx` into module-level constants:
- `COFFEE_PRESETS`: `[15, 30, 45, 60, 75]`
- `THEME_SWATCH_PHASES`: `[TimerPhase.BLOOM, TimerPhase.POUR, TimerPhase.WAIT, TimerPhase.IDLE]`

🎯 **Why:**
Defining arrays inside a React component's render body causes a fresh allocation on every single render. By moving these to the module scope, the arrays are allocated only once when the module is first loaded.

📈 **Impact:**
Reduces memory churn and garbage collection pressure, especially during frequent re-renders which may occur when the modal is open or updated.

📊 **Measured Improvement:**
A meaningful performance improvement was not directly measured via micro-benchmarks in this environment. However, the change follows standard React performance best practices for avoiding redundant allocations of static data. Rationale is based on minimizing the work done during each render cycle to ensure long-term UI fluidness.

---
*PR created automatically by Jules for task [8975782544960740243](https://jules.google.com/task/8975782544960740243) started by @damacus*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/damacus/coffee-pulse/pull/21" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
